### PR TITLE
#240 Replace native Locust with Locust Docker image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ See the aforementioned mentioned template for more detailed documentation.
 
 ## Requirements
 
-- [Python 3.13.1](https://www.python.org/downloads/release/python-3131/) (recommended install via [pyenv](https://github.com/pyenv/pyenv) with `pyenv install`)
-- [Locust](https://locust.io/) (install with `pip install locust`)
+- [Docker](https://www.docker.com/)
 - [Lando](https://lando.dev/) or [DDEV](https://ddev.com/)
 
 ## Getting started

--- a/benchmark-submit.sh
+++ b/benchmark-submit.sh
@@ -106,7 +106,7 @@ echo "Running Locust benchmark for 30 seconds using Docker ($LOCUST_IMAGE)..."
 
 # Run Locust via Docker
 # --network host: allows container to access the ddev/lando URLs on localhost
-# -v $(pwd): mounts current folder so container can find locustfile.py
+# -v $(pwd):/mnt/locust: mounts current folder to /mnt/locust in the container so it can find locustfile.py
 docker run --rm \
   --network host \
   -v "$(pwd):/mnt/locust" \

--- a/benchmark-submit.sh
+++ b/benchmark-submit.sh
@@ -12,6 +12,9 @@
 #
 ################################################################################
 
+# Lock the Locust image name and version to ensure stability.
+LOCUST_IMAGE="locustio/locust:2.42.6"
+
 # Load environment variables from .ddev/.env if it exists
 if [ -f ".ddev/.env" ]; then
   export $(grep -v '^#' .ddev/.env | xargs)
@@ -51,7 +54,7 @@ if [[ $# -lt 1 || ( "$1" != "ddev" && "$1" != "lando" ) ]]; then
   exit 1
 fi
 
-for tool in jq locust curl; do
+for tool in jq docker curl; do
   if ! command -v $tool &> /dev/null; then
       echo "Error: Required tool '$tool' is not installed. Please install it." >&2
       exit 1
@@ -62,7 +65,8 @@ done
 
 ENVIRONMENT=$1
 TEMP_STATS_FILE=$(mktemp)
-trap 'rm -f -- "$TEMP_STATS_FILE"' EXIT # Ensure temp file is deleted on exit
+# Ensure temp file is deleted on exit.
+trap 'rm -f -- "$TEMP_STATS_FILE"' EXIT
 
 # Ask for computer model information early
 echo ""
@@ -98,8 +102,27 @@ if [ -z "$login_url" ]; then
     exit 1
 fi
 
-echo "Running Locust benchmark for 30 seconds..."
-ULI="$login_url" locust --headless --only-summary --users 1 --spawn-rate 1 --run-time 30 --stop-timeout 5 --json -H "$HOST_URL" > "$TEMP_STATS_FILE"
+echo "Running Locust benchmark for 30 seconds using Docker ($LOCUST_IMAGE)..."
+
+# Run Locust via Docker
+# --network host: allows container to access the ddev/lando URLs on localhost
+# -v $(pwd): mounts current folder so container can find locustfile.py
+docker run --rm \
+  --network host \
+  -v "$(pwd):/mnt/locust" \
+  -e ULI="$login_url" \
+  "$LOCUST_IMAGE" \
+  -f /mnt/locust/locustfile.py \
+  --headless \
+  --only-summary \
+  --users 1 \
+  --spawn-rate 1 \
+  --run-time 30 \
+  --stop-timeout 5 \
+  --json \
+  -H "$HOST_URL" \
+  > "$TEMP_STATS_FILE"
+
 echo "Benchmark finished."
 echo "--------------------------------------------------"
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,18 +2,42 @@
 
 # Benchmark the Drupal site.
 
+# Lock the Locust image name and version to ensure stability.
+LOCUST_IMAGE="locustio/locust:2.42.6"
+
 # Ensure the first parameter is either "ddev" or "lando".
 if [[ $# -lt 1 || ( "$1" != "ddev" && "$1" != "lando" ) ]]; then
   echo "Error: First parameter must be either 'ddev' or 'lando'."
   exit 1
 fi
 
+if ! command -v docker &> /dev/null; then
+    echo "Error: Required tool 'docker' is not installed." >&2
+    exit 1
+fi
+
 # Get the Drupal login URL with drush.
 login_url="$($1 drush uli)"
 
-# Run load tests with Locust.
+# Determine host based on environment
 if [[ "$1" == "ddev" ]]; then
-  ULI="$login_url" locust --headless --users 1 --spawn-rate 1 --run-time 30 --stop-timeout 5 --only-summary -H https://drupal-benchmark.ddev.site
+  HOST_URL="https://drupal-benchmark.ddev.site"
 elif [[ "$1" == "lando" ]]; then
-  ULI="$login_url" locust --headless --users 1 --spawn-rate 1 --run-time 30 --stop-timeout 5 --only-summary -H https://drupal-benchmark.lndo.site
+  HOST_URL="https://drupal-benchmark.lndo.site"
 fi
+
+echo "Running Locust benchmark using Docker image: $LOCUST_IMAGE"
+
+docker run --rm \
+  --network host \
+  -v "$(pwd):/mnt/locust" \
+  -e ULI="$login_url" \
+  "$LOCUST_IMAGE" \
+  -f /mnt/locust/locustfile.py \
+  --headless \
+  --users 1 \
+  --spawn-rate 1 \
+  --run-time 30 \
+  --stop-timeout 5 \
+  --only-summary \
+  -H "$HOST_URL"


### PR DESCRIPTION
## Description

This pull request updates the benchmarking scripts to use Docker for running Locust load tests, ensuring consistent and stable test environments. The changes also introduce version locking for the Locust Docker image and improve dependency checks.

## Testing

Run the tests in the main branch
```
git checkout main
./benchmark.sh ddev
./benchmark-submit.sh ddev
```


Try again in this branch:
```
git checkout feature/#240-replace-native-Locust-with-Docker-image
./benchmark.sh ddev
./benchmark-submit.sh ddev
```

Try the same with Lando. 

First shut down ddev

` ddev poweroff`

Then start Lando

`lando start`

Run the tests in the main branch
```
git checkout main
./benchmark.sh lando
./benchmark-submit.sh lando
```

Try again in this branch:
```
git checkout feature/#240-replace-native-Locust-with-Docker-image
./benchmark.sh lando
./benchmark-submit.sh lando
```
