### PR TITLE
#320 Fix removing undefined array warning when ddev starts, remove Drupal cache disable for Lando

### DIFF
--- a/.ddev/.env
+++ b/.ddev/.env
@@ -1,3 +1,7 @@
+# Local env settings for Drupal.
+HASH_SALT=notsosecurehash
+ENVIRONMENT_NAME=ddev
+
 # supabase.com dev api url:
 NEXT_PUBLIC_SUPABASE_URL=https://gvkfqkhwvjrddscdlwft.supabase.co
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -7,19 +7,22 @@
 
 // Database settings, overridden per environment.
 $databases = [];
-$databases['default']['default'] = [
-  'database' => $_ENV['DB_NAME_DRUPAL'],
-  'username' => $_ENV['DB_USER_DRUPAL'],
-  'password' => $_ENV['DB_PASS_DRUPAL'],
-  'prefix' => '',
-  'host' => $_ENV['DB_HOST_DRUPAL'],
-  'port' => '3306',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-];
 
-// Salt for one-time login links, cancel links, form tokens, etc.
-$settings['hash_salt'] = $_ENV['HASH_SALT'];
+if (getenv('LANDO')) {
+  $databases['default']['default'] = [
+    'database' => $_ENV['DB_NAME_DRUPAL'],
+    'username' => $_ENV['DB_USER_DRUPAL'],
+    'password' => $_ENV['DB_PASS_DRUPAL'],
+    'prefix' => '',
+    'host' => $_ENV['DB_HOST_DRUPAL'],
+    'port' => '3306',
+    'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+    'driver' => 'mysql',
+  ];
+
+  // Salt for one-time login links, cancel links, form tokens, etc.
+  $settings['hash_salt'] = $_ENV['HASH_SALT'];
+}
 
 // Location of the site configuration files.
 $settings['config_sync_directory'] = '../config/sync';

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -64,7 +64,7 @@ switch ($env) {
     $settings['skip_permissions_hardening'] = TRUE;
     // Skip trusted host pattern.
     $settings['trusted_host_patterns'] = ['.*'];
-    // Debug mode on lando.
+    // Enable CSS and JS preprocess.
     $config['system.performance']['css']['preprocess'] = TRUE;
     $config['system.performance']['js']['preprocess'] = TRUE;
     break;

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -7,17 +7,18 @@
 
 // Database settings, overridden per environment.
 $databases = [];
+$databases['default']['default']['prefix'] = '';
+$databases['default']['default']['port'] = '3306';
+$databases['default']['default']['namespace'] = 'Drupal\\Core\\Database\\Driver\\mysql';
+$databases['default']['default']['driver'] = 'mysql';
 
-$databases['default']['default'] = [
-  'database' => $_ENV['DB_NAME_DRUPAL'] ?? '',
-  'username' => $_ENV['DB_USER_DRUPAL'] ?? '',
-  'password' => $_ENV['DB_PASS_DRUPAL'] ?? '',
-  'prefix' => '',
-  'host' => $_ENV['DB_HOST_DRUPAL'] ?? '',
-  'port' => '3306',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-];
+// Lando settings.
+if (getenv('LANDO') === 'ON') {
+  $databases['default']['default']['database'] = $_ENV['DB_NAME_DRUPAL'] ?? '';
+  $databases['default']['default']['username'] = $_ENV['DB_USER_DRUPAL'] ?? '';
+  $databases['default']['default']['password'] = $_ENV['DB_PASS_DRUPAL'] ?? '';
+  $databases['default']['default']['host'] = $_ENV['DB_HOST_DRUPAL'] ?? '';
+}
 
 // Salt for one-time login links, cancel links, form tokens, etc.
 $settings['hash_salt'] = $_ENV['HASH_SALT'] ?? '';

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -8,21 +8,19 @@
 // Database settings, overridden per environment.
 $databases = [];
 
-if (getenv('LANDO')) {
-  $databases['default']['default'] = [
-    'database' => $_ENV['DB_NAME_DRUPAL'],
-    'username' => $_ENV['DB_USER_DRUPAL'],
-    'password' => $_ENV['DB_PASS_DRUPAL'],
-    'prefix' => '',
-    'host' => $_ENV['DB_HOST_DRUPAL'],
-    'port' => '3306',
-    'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-    'driver' => 'mysql',
-  ];
+$databases['default']['default'] = [
+  'database' => $_ENV['DB_NAME_DRUPAL'] ?? '',
+  'username' => $_ENV['DB_USER_DRUPAL'] ?? '',
+  'password' => $_ENV['DB_PASS_DRUPAL'] ?? '',
+  'prefix' => '',
+  'host' => $_ENV['DB_HOST_DRUPAL'] ?? '',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+];
 
-  // Salt for one-time login links, cancel links, form tokens, etc.
-  $settings['hash_salt'] = $_ENV['HASH_SALT'];
-}
+// Salt for one-time login links, cancel links, form tokens, etc.
+$settings['hash_salt'] = $_ENV['HASH_SALT'] ?? '';
 
 // Location of the site configuration files.
 $settings['config_sync_directory'] = '../config/sync';

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -58,19 +58,15 @@ switch ($env) {
 
   case 'local':
   case 'lando':
+  case 'ddev':
     $settings['simple_environment_indicator'] = 'DarkGreen Local';
     // Skip file system permissions hardening.
     $settings['skip_permissions_hardening'] = TRUE;
     // Skip trusted host pattern.
     $settings['trusted_host_patterns'] = ['.*'];
     // Debug mode on lando.
-    $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
-    $config['system.performance']['css']['preprocess'] = FALSE;
-    $config['system.performance']['js']['preprocess'] = FALSE;
-    $settings['cache']['bins']['render'] = 'cache.backend.null';
-    $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
-    $settings['cache']['bins']['page'] = 'cache.backend.null';
-    $settings['extension_discovery_scan_tests'] = FALSE;
+    $config['system.performance']['css']['preprocess'] = TRUE;
+    $config['system.performance']['js']['preprocess'] = TRUE;
     break;
 
   default:


### PR DESCRIPTION
## Desciption

This pull request updates the `web/sites/default/settings.php` file to improve support for local development environments by conditionally setting database configuration and security settings when running in Lando. This in return fixes the issue with unknown array when running DDEV as we don't have those env variables set there.

## Screenshots

<img width="546" height="161" alt="Image" src="https://github.com/user-attachments/assets/35efc69f-2f7c-4f64-b935-409d0e5bd80e" />

## Testing

Check that DDEV works.
```
ddev start
ddev drush uli
```

Close DDEV:
`ddev poweroff`

Check that Lando works.
```
lando start
lando drush uli

```