### PR TITLE
Increase CPU column width to 320px for better readability

### DIFF
--- a/next/app/benchmark-table.tsx
+++ b/next/app/benchmark-table.tsx
@@ -125,7 +125,11 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 className={`px-3 py-2 font-medium cursor-pointer ${header.isNumeric ? 'text-right' : ''}`}
                 onClick={() => requestSort(header.key)}
                 style={
-                  header.key === 'databaseType' ? { width: '160px' } : undefined
+                  header.key === 'databaseType'
+                    ? { width: '160px' }
+                    : header.key === 'cpu'
+                      ? { width: '320px' }
+                      : undefined
                 }
               >
                 {header.label}
@@ -153,7 +157,7 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 <td className="px-3 py-2 whitespace-nowrap">{formattedDate}</td>
                 <td className="px-3 py-2 font-medium">{item.computerModel}</td>
                 <td className="px-3 py-2">{item.os}</td>
-                <td className="px-3 py-2 truncate max-w-xs">{item.cpu}</td>
+                <td className="px-3 py-2 truncate" style={{ width: '320px' }}>{item.cpu}</td>
                 <td className="px-3 py-2">{item.memory}</td>
                 <td className="px-3 py-2 font-mono text-xs">
                   {item.dockerVersion}

--- a/next/app/benchmark-table.tsx
+++ b/next/app/benchmark-table.tsx
@@ -92,6 +92,17 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
     return sortConfig.direction === 'asc' ? ' ▲' : ' ▼';
   };
 
+  // Helper function to get column width style
+  const getColumnWidth = (key: SortKey): { width: string } | undefined => {
+    if (key === 'databaseType') {
+      return { width: '160px' };
+    }
+    if (key === 'cpu') {
+      return { width: '320px' };
+    }
+    return undefined;
+  };
+
   // An array to define our table headers for easier mapping
   const headers: { key: SortKey; label: string; isNumeric?: boolean }[] = [
     { key: 'createdAt', label: 'Date' },
@@ -124,13 +135,7 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 key={header.key}
                 className={`px-3 py-2 font-medium cursor-pointer ${header.isNumeric ? 'text-right' : ''}`}
                 onClick={() => requestSort(header.key)}
-                style={
-                  header.key === 'databaseType'
-                    ? { width: '160px' }
-                    : header.key === 'cpu'
-                      ? { width: '320px' }
-                      : undefined
-                }
+                style={getColumnWidth(header.key)}
               >
                 {header.label}
                 {getSortArrow(header.key)}
@@ -157,7 +162,9 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 <td className="px-3 py-2 whitespace-nowrap">{formattedDate}</td>
                 <td className="px-3 py-2 font-medium">{item.computerModel}</td>
                 <td className="px-3 py-2">{item.os}</td>
-                <td className="px-3 py-2 truncate" style={{ width: '320px' }}>{item.cpu}</td>
+                <td className="px-3 py-2 truncate" style={{ width: '320px' }}>
+                  {item.cpu}
+                </td>
                 <td className="px-3 py-2">{item.memory}</td>
                 <td className="px-3 py-2 font-mono text-xs">
                   {item.dockerVersion}

--- a/next/app/benchmark-table.tsx
+++ b/next/app/benchmark-table.tsx
@@ -162,7 +162,10 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 <td className="px-3 py-2 whitespace-nowrap">{formattedDate}</td>
                 <td className="px-3 py-2 font-medium">{item.computerModel}</td>
                 <td className="px-3 py-2">{item.os}</td>
-                <td className="px-3 py-2 truncate" style={{ width: '320px' }}>
+                <td
+                  className="px-3 py-2 truncate"
+                  style={getColumnWidth('cpu')}
+                >
                   {item.cpu}
                 </td>
                 <td className="px-3 py-2">{item.memory}</td>
@@ -172,7 +175,10 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 <td className="px-3 py-2 font-mono">{item.environment}</td>
                 <td className="px-3 py-2 font-mono">{item.drupalVersion}</td>
                 <td className="px-3 py-2 font-mono">{item.webServer}</td>
-                <td className="px-3 py-2 font-mono" style={{ width: '160px' }}>
+                <td
+                  className="px-3 py-2 font-mono"
+                  style={getColumnWidth('databaseType')}
+                >
                   {item.databaseType} {item.databaseVersion}
                 </td>
                 <td className="px-3 py-2 font-mono">{item.phpVersion}</td>


### PR DESCRIPTION
## Description 

This pull request makes minor UI adjustments to the `BenchmarkTable` component to improve the display of the CPU column. The changes ensure consistent column width for the CPU field in both the table header and body.

* UI consistency:
  * Set the width of the CPU column to 320px in both the table header and table body, ensuring alignment and improved readability. [[1]](diffhunk://#diff-aac3c20f6eab08b418520299e58e8be860a285c1ebc885cb072150e39977ab01L128-R132) [[2]](diffhunk://#diff-aac3c20f6eab08b418520299e58e8be860a285c1ebc885cb072150e39977ab01L156-R160)

## Screenshots

Before
<img width="1118" height="310" alt="Screenshot 2025-12-20 at 08 11 54" src="https://github.com/user-attachments/assets/788fa68f-78fb-41e0-97e6-16669eb4ddf5" />

After
<img width="1125" height="310" alt="Screenshot 2025-12-20 at 09 05 55" src="https://github.com/user-attachments/assets/c58587df-263a-45a5-988e-0dd6ea53aed9" />

## Testing

You can see the changes already at https://drupal-benchmark.vercel.app/