### PR TITLE
Add Benchmark version column to results table

### DIFF
--- a/benchmark-submit.sh
+++ b/benchmark-submit.sh
@@ -141,8 +141,8 @@ gather_metadata() {
   os_name=$(uname -s)
   arch=$(uname -m)
   git_commit=$(git rev-parse --short HEAD)
-  # Get benchmark version from composer.json, or fall back to commit hash
-  benchmark_version=$(jq -r '.version // empty' composer.json 2>/dev/null || echo "$git_commit")
+  # Get benchmark version from composer.json; fallback to commit hash handled below
+  benchmark_version=$(jq -r '.version // ""' composer.json 2>/dev/null)
   if [ -z "$benchmark_version" ] || [ "$benchmark_version" = "null" ]; then
     benchmark_version="$git_commit"
   fi

--- a/benchmark-submit.sh
+++ b/benchmark-submit.sh
@@ -141,6 +141,11 @@ gather_metadata() {
   os_name=$(uname -s)
   arch=$(uname -m)
   git_commit=$(git rev-parse --short HEAD)
+  # Get benchmark version from composer.json, or fall back to commit hash
+  benchmark_version=$(jq -r '.version // empty' composer.json 2>/dev/null || echo "$git_commit")
+  if [ -z "$benchmark_version" ] || [ "$benchmark_version" = "null" ]; then
+    benchmark_version="$git_commit"
+  fi
   drupal_version=$($ENVIRONMENT drush status --field=drupal-version)
 
   # Web server detection
@@ -233,6 +238,7 @@ gather_metadata() {
     --arg environment "$environment_with_version" \
     --arg user_name "$user_name" \
     --arg git_commit "$git_commit" \
+    --arg benchmark_version "$benchmark_version" \
     --arg drupal_version "$drupal_version" \
     --arg docker_version "$docker_version" \
     --arg web_server "$web_server" \
@@ -242,7 +248,7 @@ gather_metadata() {
     --arg computer_model "$COMPUTER_MODEL" \
     --arg benchmark_comment "$BENCHMARK_COMMENT" \
     --argjson system_info "$(jq -n --arg os "$os_name" --arg arch "$arch" --arg cpu "$cpu_info" --arg mem "${total_mem_gb}GB" '{os:$os, arch:$arch, cpu:$cpu, memory:$mem}')" \
-    '{metadata: {environment:$environment, user_name:$user_name, commit:$git_commit, drupal_version:$drupal_version, docker_version:$docker_version, web_server:$web_server, database:{type:$db_type, version:$db_version}, php_version:$php_version, computer_model:$computer_model, comment:$benchmark_comment, system:$system_info}}'
+    '{metadata: {environment:$environment, user_name:$user_name, commit:$git_commit, benchmark_version:$benchmark_version, drupal_version:$drupal_version, docker_version:$docker_version, web_server:$web_server, database:{type:$db_type, version:$db_version}, php_version:$php_version, computer_model:$computer_model, comment:$benchmark_comment, system:$system_info}}'
 }
 
 echo "Preparing data for submission..."

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "wunderio/drupal-project",
+    "version": "1.0",
     "description": "Wunder's template for Drupal 9 projects.",
     "type": "project",
     "license": "GPL-2.0-or-later",

--- a/next/app/benchmark-table.tsx
+++ b/next/app/benchmark-table.tsx
@@ -19,6 +19,7 @@ interface ProcessedBenchmark {
   phpVersion: string;
   computerModel: string;
   comment: string;
+  benchmarkVersion: string;
   numRequests: number;
   requestsPerSecond: number;
   avgResponseTime: number;
@@ -46,6 +47,7 @@ type SortKey =
   | 'phpVersion'
   | 'computerModel'
   | 'comment'
+  | 'benchmarkVersion'
   | 'numRequests'
   | 'requestsPerSecond'
   | 'avgResponseTime'
@@ -112,6 +114,7 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
     { key: 'maxResponseTime', label: 'Max (ms)', isNumeric: true },
     { key: 'comment', label: 'Comment' },
     { key: 'username', label: 'User' },
+    { key: 'benchmarkVersion', label: 'Benchmark version' },
   ];
 
   return (
@@ -182,6 +185,7 @@ export default function BenchmarkTable({ data }: BenchmarkTableProps) {
                 </td>
                 <td className="px-3 py-2">{item.comment}</td>
                 <td className="px-3 py-2 font-medium">{item.username}</td>
+                <td className="px-3 py-2 font-mono">{item.benchmarkVersion}</td>
               </tr>
             );
           })}

--- a/next/app/page.tsx
+++ b/next/app/page.tsx
@@ -26,6 +26,7 @@ interface ProcessedBenchmark {
   phpVersion: string;
   computerModel: string;
   comment: string;
+  benchmarkVersion: string;
   numRequests: number;
   requestsPerSecond: number;
   avgResponseTime: number;
@@ -86,6 +87,7 @@ export default async function Home() {
         phpVersion: record.metadata.php_version || 'Unknown',
         computerModel: record.metadata.computer_model || 'Unknown',
         comment: record.metadata.comment || '',
+        benchmarkVersion: record.metadata.benchmark_version || 'Unknown',
         numRequests,
         requestsPerSecond: parseFloat(requestsPerSecond),
         avgResponseTime,


### PR DESCRIPTION
## Description

This pull request introduces a new `benchmarkVersion` field to track the version of the benchmark used in submissions, improving traceability and transparency. The version is extracted from `composer.json` if available, or falls back to the git commit hash (becuase why not :) ). The field is now included in the metadata collected by the benchmark script and displayed in the frontend benchmark table.

## Screenshots

Normally takes version from compose.json, but if for some reason it's not there, then git commit:
<img width="651" height="275" alt="Screenshot 2025-12-20 at 08 44 41" src="https://github.com/user-attachments/assets/10902567-51c8-44fe-b07b-d44a8680c91f" />


## Testing 

Checkout `develop` branch as I've gathered all the latest changes there.
```bash
git checkout develop
```


Run test
```bash
 ./benchmark-submit.sh ddev
```

Check results:
```bash
https://drupal-benchmark.vercel.app/
```